### PR TITLE
return the existing remote_file_url if it's present and no report is attached

### DIFF
--- a/app/concerns/report_generator/active_storage_download_adapter.rb
+++ b/app/concerns/report_generator/active_storage_download_adapter.rb
@@ -6,6 +6,8 @@ module ReportGenerator::ActiveStorageDownloadAdapter
   end
 
   def expiring_link(expires_in: ReportGenerator::Download::MAX_EXPIRY)
+    return self.remote_file_url if self.remote_file_url.present? && !self.report.attached?
+
     if %i[local test].include?(Rails.application.config.active_storage.service)
       ActiveStorage::Current.host = ReportGenerator.config.local_storage_host
     end


### PR DESCRIPTION
this implies that the file was handled by dragonfly so the service_url won't work.

rew-1167