### PR TITLE
Fix service_url deprecation for rails 7.0

### DIFF
--- a/app/concerns/report_generator/active_storage_download_adapter.rb
+++ b/app/concerns/report_generator/active_storage_download_adapter.rb
@@ -12,6 +12,6 @@ module ReportGenerator::ActiveStorageDownloadAdapter
       ActiveStorage::Current.host = ReportGenerator.config.local_storage_host
     end
 
-    self.report.service_url(expires_in: expires_in.to_i, disposition: "attachment")
+    self.report.url(expires_in: expires_in.to_i, disposition: "attachment")
   end
 end


### PR DESCRIPTION
Fix service_url deprecation for rails 7.0 by changing it to use url