### PR TITLE
REW-2134 Using Current.url_options.host instead of Current.host as deprecated

### DIFF
--- a/app/concerns/report_generator/active_storage_download_adapter.rb
+++ b/app/concerns/report_generator/active_storage_download_adapter.rb
@@ -9,7 +9,7 @@ module ReportGenerator::ActiveStorageDownloadAdapter
     return self.remote_file_url if self.remote_file_url.present? && !self.report.attached?
 
     if %i[local test].include?(Rails.application.config.active_storage.service)
-      ActiveStorage::Current.host = ReportGenerator.config.local_storage_host
+      ActiveStorage::Current.url_options.host = ReportGenerator.config.local_storage_host
     end
 
     self.report.url(expires_in: expires_in.to_i, disposition: "attachment")

--- a/app/concerns/report_generator/active_storage_download_adapter.rb
+++ b/app/concerns/report_generator/active_storage_download_adapter.rb
@@ -9,7 +9,7 @@ module ReportGenerator::ActiveStorageDownloadAdapter
     return self.remote_file_url if self.remote_file_url.present? && !self.report.attached?
 
     if %i[local test].include?(Rails.application.config.active_storage.service)
-      ActiveStorage::Current.url_options.host = ReportGenerator.config.local_storage_host
+      ActiveStorage::Current.url_options = { host: ReportGenerator.config.local_storage_host }
     end
 
     self.report.url(expires_in: expires_in.to_i, disposition: "attachment")


### PR DESCRIPTION
Using Current.url_options.host instead of Current.host as it is deprecated